### PR TITLE
✨ Add support for retrieving non-SNAPSHOT versions

### DIFF
--- a/github-package-repo/src/main/java/com/github/rmcdouga/ghrepo/GithubPackages.java
+++ b/github-package-repo/src/main/java/com/github/rmcdouga/ghrepo/GithubPackages.java
@@ -65,6 +65,16 @@ public class GithubPackages {
 	private GetResult internalGet(String userOrg, String repo, String groupId, String artifactId, String version, String artifactExtension)
 			throws IOException {
 		String path = "/%s/%s/%s/%s/%s/".formatted(userOrg, repo, groupId.replace('.', '/'), artifactId, version);
+		return version.endsWith("SNAPSHOT") ? getSnapshot(artifactId, artifactExtension, path) 
+											: getFinal(artifactId, version, artifactExtension, path);
+	}
+
+	private GetResult getFinal(String artifactId, String version, String artifactExtension, String path) throws IOException {
+		// https://maven.pkg.github.com/4PointSolutions/FluentFormsAPI/com/_4point/aem/fluentforms.core/0.0.3/fluentforms.core-0.0.3.jar
+		return new GetResult(restClient.get("%s%s-%s.%s".formatted(path, artifactId, version, artifactExtension)), artifactId);
+	}
+
+	private GetResult getSnapshot(String artifactId, String artifactExtension, String path) throws IOException {
 		// Get the Maven Metadata first
 		byte[] metadataBytes = restClient.get(path + "maven-metadata.xml").readAllBytes();
 		try {

--- a/github-package-repo/src/test/java/com/github/rmcdouga/ghrepo/GithubPackagesTest.java
+++ b/github-package-repo/src/test/java/com/github/rmcdouga/ghrepo/GithubPackagesTest.java
@@ -32,11 +32,13 @@ class GithubPackagesTest {
 	private static final String REPO = "WatchedFolderUtils";
 	private static final String GROUP_ID = "com._4point.aem.watchedfolder";
 	private static final String ARTIFACT_ID = "watched-folder-poster";
-	private static final String VERSION = "0.0.1-SNAPSHOT";
+	private static final String SNAPSHOT_VERSION = "0.0.1-SNAPSHOT";
+	private static final String FINAL_VERSION = "0.0.1";
 	private static final String JAR_EXTENSION = "jar";
 	
 	private static final String EXPECTED_METADATA_LOCATION = "/4PointSolutions/WatchedFolderUtils/com/_4point/aem/watchedfolder/watched-folder-poster/0.0.1-SNAPSHOT/" + METADATA_NAME;
-	private static final String EXPECTED_JAR_LOCATION = "/4PointSolutions/WatchedFolderUtils/com/_4point/aem/watchedfolder/watched-folder-poster/0.0.1-SNAPSHOT/watched-folder-poster-0.0.1-20221221.221800-4.jar";
+	private static final String EXPECTED_SNAPSHOT_JAR_LOCATION = "/4PointSolutions/WatchedFolderUtils/com/_4point/aem/watchedfolder/watched-folder-poster/0.0.1-SNAPSHOT/watched-folder-poster-0.0.1-20221221.221800-4.jar";
+	private static final String EXPECTED_FINAL_JAR_LOCATION = "/4PointSolutions/WatchedFolderUtils/com/_4point/aem/watchedfolder/watched-folder-poster/0.0.1/watched-folder-poster-0.0.1.jar";
 
 	@Mock InputStream expectedResult;
 	@Captor ArgumentCaptor<String> restEndpoint;
@@ -54,27 +56,49 @@ class GithubPackagesTest {
         R apply(T t) throws E;
     }
     
-	@DisplayName("Test GithinPackages.get() method in all it's forms.")
+	@DisplayName("Test GithinPackages.get() method in all it's forms with SNAPSHOT version.")
 	@ParameterizedTest
-	@MethodSource("testFns")
-	void testGet(Function_WithExceptions<GithubPackages, InputStream, IOException> underTestFn) throws Exception {
+	@MethodSource("testSnapshotFns")
+	void testSnapshotGet(Function_WithExceptions<GithubPackages, InputStream, IOException> underTestFn) throws Exception {
 		Mockito.when(mockRestClient.get(Mockito.endsWith(METADATA_NAME))).thenReturn(Files.newInputStream(TestUtils.SAMPLE_FILES_DIR.resolve(METADATA_NAME)));
 		Mockito.when(mockRestClient.get(Mockito.endsWith(".jar"))).thenReturn(expectedResult);
 		InputStream result = underTestFn.apply(underTest);
 		assertSame(expectedResult, result);
 		Mockito.verify(mockRestClient).get(EXPECTED_METADATA_LOCATION);
-		Mockito.verify(mockRestClient).get(EXPECTED_JAR_LOCATION);
+		Mockito.verify(mockRestClient).get(EXPECTED_SNAPSHOT_JAR_LOCATION);
 	}
 
 	// Iterate through all the fluent functions.
-	static List<Function_WithExceptions<GithubPackages, InputStream, IOException>> testFns() {
+	static List<Function_WithExceptions<GithubPackages, InputStream, IOException>> testSnapshotFns() {
 		return List.of(
-				(ghp)->ghp.get(USER_ORG_ID, REPO, GROUP_ID, ARTIFACT_ID, VERSION),
-				(ghp)->ghp.repo(USER_ORG_ID, REPO).get(GROUP_ID, ARTIFACT_ID, VERSION),
-				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).get(ARTIFACT_ID, VERSION),
-				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).get(VERSION),
-				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).version(VERSION).get(),
-				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).version(VERSION).extension(JAR_EXTENSION).get()
+				(ghp)->ghp.get(USER_ORG_ID, REPO, GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).get(GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).get(ARTIFACT_ID, SNAPSHOT_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).get(SNAPSHOT_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).version(SNAPSHOT_VERSION).get(),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).version(SNAPSHOT_VERSION).extension(JAR_EXTENSION).get()
+				); 
+	}
+	
+	@DisplayName("Test GithinPackages.get() method in all it's forms with final version.")
+	@ParameterizedTest
+	@MethodSource("testFinalFns")
+	void testGet(Function_WithExceptions<GithubPackages, InputStream, IOException> underTestFn) throws Exception {
+		Mockito.when(mockRestClient.get(Mockito.endsWith(".jar"))).thenReturn(expectedResult);
+		InputStream result = underTestFn.apply(underTest);
+		assertSame(expectedResult, result);
+		Mockito.verify(mockRestClient).get(EXPECTED_FINAL_JAR_LOCATION);
+	}
+
+	// Iterate through all the fluent functions.
+	static List<Function_WithExceptions<GithubPackages, InputStream, IOException>> testFinalFns() {
+		return List.of(
+				(ghp)->ghp.get(USER_ORG_ID, REPO, GROUP_ID, ARTIFACT_ID, FINAL_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).get(GROUP_ID, ARTIFACT_ID, FINAL_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).get(ARTIFACT_ID, FINAL_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).get(FINAL_VERSION),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).version(FINAL_VERSION).get(),
+				(ghp)->ghp.repo(USER_ORG_ID, REPO).group(GROUP_ID).artifact(ARTIFACT_ID).version(FINAL_VERSION).extension(JAR_EXTENSION).get()
 				); 
 	}
 	
@@ -86,7 +110,7 @@ class GithubPackagesTest {
 	@Test
 	void testGet_Integration() throws Exception {
 		String failureResultsFilename = "GithubPackagesTest_testGet_IntTest_results.txt";
-		InputStream result = GithubPackages.create().get(USER_ORG_ID, REPO, GROUP_ID, ARTIFACT_ID, VERSION);
+		InputStream result = GithubPackages.create().get(USER_ORG_ID, REPO, GROUP_ID, ARTIFACT_ID, SNAPSHOT_VERSION);
 		byte[] resultBytes = result.readAllBytes();
 		boolean isArchive = isArchive(resultBytes);
 		if (!isArchive) {
@@ -104,9 +128,9 @@ class GithubPackagesTest {
 					  .repo(USER_ORG_ID, REPO)
 					  .group(GROUP_ID)
 					  .artifact(ARTIFACT_ID)
-					  .version(VERSION)
+					  .version(SNAPSHOT_VERSION)
 					  .copyTo(resultsFilename);
-		assertTrue(Files.exists(resultsFilename), "Expecte '" + resultsFilename + "' to exist but it does not.");
+		assertTrue(Files.exists(resultsFilename), "Expected '" + resultsFilename + "' to exist but it does not.");
 		assertTrue(isArchive(Files.readAllBytes(resultsFilename)), "Expected response to be a .zip/.jar but is was not. Results written to actualResults directory.");
 	}
 
@@ -114,14 +138,14 @@ class GithubPackagesTest {
 	@DisplayName("Integration test - test GithinPackages.fluent copyTo directory method.")
 	@Test
 	void testCopyToDir(@TempDir Path tempDir) throws Exception {
-		Path expectedResultsFilename = tempDir.resolve("%s-%s.jar".formatted(ARTIFACT_ID, VERSION));
+		Path expectedResultsFilename = tempDir.resolve("%s-%s.jar".formatted(ARTIFACT_ID, SNAPSHOT_VERSION));
 		GithubPackages.create()
 					  .repo(USER_ORG_ID, REPO)
 					  .group(GROUP_ID)
 					  .artifact(ARTIFACT_ID)
-					  .version(VERSION)
+					  .version(SNAPSHOT_VERSION)
 					  .copyTo(tempDir);
-		assertTrue(Files.exists(expectedResultsFilename), "Expecte '" + expectedResultsFilename + "' to exist but it does not.");
+		assertTrue(Files.exists(expectedResultsFilename), "Expected '" + expectedResultsFilename + "' to exist but it does not.");
 		assertTrue(isArchive(Files.readAllBytes(expectedResultsFilename)), "Expected response to be a .zip/.jar but is was not. Results written to actualResults directory.");
 	}
 
@@ -130,7 +154,9 @@ class GithubPackagesTest {
 	@ParameterizedTest
 	@CsvSource(value = {
 			"4PointSolutions,FluentFormsAPI,com._4point.aem,fluentforms.core,0.0.2-SNAPSHOT",
-			"4PointSolutions,FluentFormsAPI,com._4point.aem.docservices,rest-services.client,0.0.2-SNAPSHOT"
+			"4PointSolutions,FluentFormsAPI,com._4point.aem.docservices,rest-services.client,0.0.2-SNAPSHOT",
+			"4PointSolutions,FluentFormsAPI,com._4point.aem,fluentforms.core,0.0.3",
+			"4PointSolutions,FluentFormsAPI,com._4point.aem.docservices,rest-services.client,0.0.3"
 	})
 	void testCopyToDirOtherRepos(String userOrg, String repo, String groupId, String artifactId, String version, @TempDir Path tempDir) throws Exception {
 		Path expectedResultsFilename = tempDir.resolve("%s-%s.jar".formatted(artifactId, version));
@@ -140,7 +166,7 @@ class GithubPackagesTest {
 					  .artifact(artifactId)
 					  .version(version)
 					  .copyTo(tempDir.resolve(expectedResultsFilename));
-		assertTrue(Files.exists(expectedResultsFilename), "Expecte '" + expectedResultsFilename + "' to exist but it does not.");
+		assertTrue(Files.exists(expectedResultsFilename), "Expected '" + expectedResultsFilename + "' to exist but it does not.");
 		assertTrue(isArchive(Files.readAllBytes(expectedResultsFilename)), "Expected response to be a .zip/.jar but is was not. Results written to actualResults directory.");
 	}
 


### PR DESCRIPTION
Previously, only SNAPSHOT versions could be retrieved, now not SNAPSHOT and final versions can be retrieved.